### PR TITLE
Add an example CI workflow

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -1,0 +1,37 @@
+name: Tests
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    types:
+      - opened
+      - synchronize
+  merge_group:
+    types:
+      - checks_requested
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' || github.event_name == 'merge_group' }}
+
+jobs:
+  tests:
+    name: Tests (${{ matrix.version }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        version:
+          - main
+          - latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Build
+        run: |
+          docker compose build --build-arg TENZIR_VERSION=${{ matrix.version }}
+      - name: Test
+        run: |
+          docker compose run tests
+          git diff --exit-code

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
-FROM tenzir/tenzir-dev:main AS example-builder-untested
+ARG TENZIR_VERSION=main
+FROM ghcr.io/tenzir/tenzir-dev:${TENZIR_VERSION} AS example-builder-untested
 
 COPY example /plugins/example
 
@@ -9,6 +10,7 @@ RUN cmake --install build-example --strip --component Runtime --prefix /plugin/e
 FROM example-builder-untested AS example-test
 
 ENV BATS_LIB_PATH=/tmp/tenzir/tenzir/integration/lib
+# TODO: Use the update-integration target instead
 ENV UPDATE=1
 
 ENTRYPOINT cmake --build build-example --target integration
@@ -18,6 +20,6 @@ FROM example-builder-untested AS example-builder
 ENV BATS_LIB_PATH=/tmp/tenzir/tenzir/integration/lib
 RUN cmake --build build-example --target integration
 
-FROM tenzir/tenzir:main
+FROM ghcr.io/tenzir/tenzir:${TENZIR_VERSION}
 
 COPY --from=example-builder --chown=tenzir:tenzir /plugin/example /opt/tenzir

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -2,6 +2,8 @@ services:
   tenzir-node:
     build:
       context: .
+      args:
+        - TENZIR_VERSION=main
     environment:
       - TENZIR_ALLOW_UNSAFE_PIPELINES=true
       - TENZIR_ENDPOINT=tenzir-node:5158
@@ -24,6 +26,8 @@ services:
   tenzir:
     build:
       context: .
+      args:
+        - TENZIR_VERSION=main
     profiles:
       - donotstart
     depends_on:
@@ -38,6 +42,8 @@ services:
     build:
       context: .
       target: example-test
+      args:
+        - TENZIR_VERSION=main
     profiles:
       - donotstart
     volumes:


### PR DESCRIPTION
This adds a CI workflow for the example plugin that builds and tests against the current development version and the last release of Tenzir.