### PR TITLE
Specify `--build` option for Docker Compose in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,12 +5,12 @@ whitespace from string fields.
 
 ## Build and run
 
-Simply run `docker compose up` to build and start a Tenzir node with your
-additional plugin.
+Simply run `docker compose up --build` to build and start a Tenzir node with
+your additional plugin.
 
-Use `docker compose run tenzir '<pipeline>'` to interact with the node on the
-command-line, or set the following environment variables connect your node to
-app.tenzir.com:
+Use `docker compose run --build tenzir '<pipeline>'` to interact with the node
+on the command-line, or set the following environment variables connect your
+node to app.tenzir.com:
 
 ```
 export TENZIR_PLUGINS__PLATFORM__API_KEY='<api-key>'


### PR DESCRIPTION
This is much less error-prone for people new to working with Docker, and experienced users will know when they're able to omit it.