### PR TITLE
Use separate volumes in docker-compose

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -14,9 +14,8 @@ services:
     entrypoint:
       - tenzir-node
     volumes:
-      - tenzir-node:/var/lib/tenzir/
-      - tenzir-node:/var/log/tenzir/
-      - tenzir-node:/var/cache/tenzir/
+      - tenzir-lib:/var/lib/tenzir/
+      - tenzir-log:/var/log/tenzir/
     healthcheck:
       test: tenzir --connection-timeout=30s --connection-retry-delay=1s 'api /ping'
       interval: 30s
@@ -33,8 +32,6 @@ services:
       - tenzir-node
     environment:
       - TENZIR_ENDPOINT=tenzir-node:5158
-    volumes:
-      - tenzir-node:/var/cache/tenzir/
 
   tests:
     build:
@@ -48,5 +45,7 @@ services:
       - ./integration/data/reference/:/plugins/example/integration/data/reference/
 
 volumes:
-  tenzir-node:
+  tenzir-lib:
+    driver: local
+  tenzir-log:
     driver: local


### PR DESCRIPTION
relates to https://github.com/tenzir/issues/issues/2322

### Reason for change

docker-compose volumes overlap which causes unintended side effects

### Change

Use separate volumes in docker-compose